### PR TITLE
Correcting the missing key names

### DIFF
--- a/kavitaemail-unraid.xml
+++ b/kavitaemail-unraid.xml
@@ -66,10 +66,10 @@
   </Environment>
   <Labels/>
   <Config Name="SMTP Relay Port" Target="5003" Default="5003" Mode="tcp" Description="Container Port: 5003" Type="Port" Display="always" Required="false" Mask="false">5003</Config>
-  <Config Name="SMTP_HOST" Target="" Default="" Mode="" Description="Your SMTP server hostname" Type="Variable" Display="always" Required="true" Mask="false"/>
-  <Config Name="SMTP_PORT" Target="" Default="" Mode="" Description="SMTP server port" Type="Variable" Display="always" Required="true" Mask="false"/>
-  <Config Name="SMTP_USER" Target="" Default="" Mode="" Description="SMTP Username" Type="Variable" Display="always" Required="true" Mask="false"/>
-  <Config Name="SMTP_PASS" Target="" Default="" Mode="" Description="SMTP password" Type="Variable" Display="always" Required="false" Mask="false"/>
-  <Config Name="SEND_ADDR" Target="" Default="" Mode="" Description="Address you want your emails to appear from" Type="Variable" Display="always" Required="true" Mask="false"/>
-  <Config Name="DISP_NAME" Target="" Default="" Mode="" Description="Display name for the emails being sent" Type="Variable" Display="always" Required="true" Mask="false"/>
+  <Config Name="SMTP_HOST" Target="SMTP_HOST" Default="" Mode="" Description="Your SMTP server hostname" Type="Variable" Display="always" Required="true" Mask="false"/>
+  <Config Name="SMTP_PORT" Target="SMTP_PORT" Default="" Mode="" Description="SMTP server port" Type="Variable" Display="always" Required="true" Mask="false"/>
+  <Config Name="SMTP_USER" Target="SMTP_USER" Default="" Mode="" Description="SMTP Username" Type="Variable" Display="always" Required="true" Mask="false"/>
+  <Config Name="SMTP_PASS" Target="SMTP_PASS" Default="" Mode="" Description="SMTP password" Type="Variable" Display="always" Required="false" Mask="false"/>
+  <Config Name="SEND_ADDR" Target="SEND_ADDR" Default="" Mode="" Description="Address you want your emails to appear from" Type="Variable" Display="always" Required="true" Mask="false"/>
+  <Config Name="DISP_NAME" Target="DISP_NAME" Default="" Mode="" Description="Display name for the emails being sent" Type="Variable" Display="always" Required="true" Mask="false"/>
 </Container>


### PR DESCRIPTION
Added the key names of the environment variables. They were not set so the environment variables were never passed on to the container.